### PR TITLE
fix: correct catalog.json grounded-sam2 repo link and yolo port

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -7,7 +7,7 @@
       "service_repo": "https://github.com/TidyBot-Services/yolo-service",
       "client_sdk": "https://raw.githubusercontent.com/TidyBot-Services/yolo-service/main/client.py",
       "api_docs": "https://github.com/TidyBot-Services/yolo-service/blob/main/README.md",
-      "host": "http://158.130.109.188:8000",
+      "host": "http://158.130.109.188:8010",
       "endpoints": [
         "GET /health",
         "POST /detect",
@@ -29,9 +29,9 @@
     "grounded-sam2": {
       "type": "model",
       "description": "Open-vocabulary object detection + segmentation. Accepts image + text prompts, returns bounding boxes, segmentation masks (PNG), and confidence scores. Uses Grounding DINO + SAM 2.",
-      "service_repo": "https://github.com/TidyBot-Services/grounded-sam2",
-      "client_sdk": "https://raw.githubusercontent.com/TidyBot-Services/grounded-sam2/main/client.py",
-      "api_docs": "https://github.com/TidyBot-Services/grounded-sam2/blob/main/README.md",
+      "service_repo": "https://github.com/TidyBot-Services/grounded-sam2-service",
+      "client_sdk": "https://raw.githubusercontent.com/TidyBot-Services/grounded-sam2-service/main/client.py",
+      "api_docs": "https://github.com/TidyBot-Services/grounded-sam2-service/blob/main/README.md",
       "host": "http://158.130.109.188:8001",
       "endpoints": [
         "GET /health",


### PR DESCRIPTION
## Problems
1. grounded-sam2 capability links to `TidyBot-Services/grounded-sam2` (raw fork, no service.yaml) instead of `TidyBot-Services/grounded-sam2-service` (actual service repo with service.yaml and proper structure)
2. yolo-detection host uses port 8000 but actual deployment is on port 8010

## Fix
- Updated grounded-sam2 service_repo, client_sdk, and api_docs URLs to point to grounded-sam2-service
- Updated yolo-detection host port to 8010

## Found by
Automated Tidybot daily audit (2026-03-03)