### PR TITLE
fix: update catalog to point to grounded-sam2-service (not deprecated repo)

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -29,9 +29,9 @@
     "grounded-sam2": {
       "type": "model",
       "description": "Open-vocabulary object detection + segmentation. Accepts image + text prompts, returns bounding boxes, segmentation masks (PNG), and confidence scores. Uses Grounding DINO + SAM 2.",
-      "service_repo": "https://github.com/TidyBot-Services/grounded-sam2",
-      "client_sdk": "https://raw.githubusercontent.com/TidyBot-Services/grounded-sam2/main/client.py",
-      "api_docs": "https://github.com/TidyBot-Services/grounded-sam2/blob/main/README.md",
+      "service_repo": "https://github.com/TidyBot-Services/grounded-sam2-service",
+      "client_sdk": "https://raw.githubusercontent.com/TidyBot-Services/grounded-sam2-service/main/client.py",
+      "api_docs": "https://github.com/TidyBot-Services/grounded-sam2-service/blob/main/README.md",
       "host": "http://158.130.109.188:8001",
       "endpoints": [
         "GET /health",


### PR DESCRIPTION
## Problem

The `grounded-sam2` entry in `catalog.json` points to the deprecated `TidyBot-Services/grounded-sam2` repo. That repo has a deprecation notice at the top of its README pointing to `grounded-sam2-service`.

Agents downloading the client SDK via the catalog URL get the old, outdated client.py instead of the current one from `grounded-sam2-service`.

## Fix

Updated `service_repo`, `client_sdk`, and `api_docs` URLs in `catalog.json` to point to `grounded-sam2-service`.

Found during weekly ecosystem audit.