### PR TITLE
fix: update YOLO service host port from 8000 to 8010 in catalog

### DIFF
--- a/catalog.json
+++ b/catalog.json
@@ -7,7 +7,7 @@
       "service_repo": "https://github.com/TidyBot-Services/yolo-service",
       "client_sdk": "https://raw.githubusercontent.com/TidyBot-Services/yolo-service/main/client.py",
       "api_docs": "https://github.com/TidyBot-Services/yolo-service/blob/main/README.md",
-      "host": "http://158.130.109.188:8000",
+      "host": "http://158.130.109.188:8010",
       "endpoints": [
         "GET /health",
         "POST /detect",


### PR DESCRIPTION
## Problem

The YOLO service entry in `catalog.json` has `host: http://158.130.109.188:8000` but the actual service runs on port 8010. Port 8000 is used by the camera extrinsic calibration service.

Agents connecting to the catalog-specified host URL would hit the wrong service (or nothing).

## Fix

Updated the YOLO host URL from port 8000 to 8010.

Found during weekly ecosystem audit.